### PR TITLE
Lock read/write bool in `resumeAnimation()`

### DIFF
--- a/Sources/SSChart/Bar/BarChart.swift
+++ b/Sources/SSChart/Bar/BarChart.swift
@@ -114,7 +114,11 @@ extension BarChart {
     }
     
     public func resumeAnimation() {
+        let lock = NSLock()
+        
         DispatchQueue.main.async { [weak self] in
+            lock.lock()
+            
             guard let self = self, !self.didAnimation else { return }
 
             for (index, bar) in self.bars.enumerated() {
@@ -126,6 +130,8 @@ extension BarChart {
             }
             
             self.didAnimation = true
+            
+            lock.unlock()
         }
     }
 }

--- a/Sources/SSChart/Doughnut/DoughnutChart.swift
+++ b/Sources/SSChart/Doughnut/DoughnutChart.swift
@@ -73,8 +73,11 @@ extension DoughnutChart {
     }
     
     public func resumeAnimation() {
-        // ???: is it right to use async, put whole block in async?
+        let lock = NSLock()
+
         DispatchQueue.main.async { [weak self] in
+            lock.lock()
+            
             guard let self = self,
                   let mask = self.doughnutLayer.mask,
                   !self.didAnimation else { return }
@@ -84,6 +87,8 @@ extension DoughnutChart {
             self.resumeAnimation(layer: mask, delay: 0)
             
             self.didAnimation = true
+            
+            lock.unlock()
         }
     }
 }

--- a/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/Sources/SSChart/Gauge/GaugeChart.swift
@@ -73,8 +73,11 @@ extension GaugeChart {
     }
     
     public func resumeAnimation() {
-        // ???: is it right to use async, put whole block in async?
+        let lock = NSLock()
+
         DispatchQueue.main.async { [weak self] in
+            lock.lock()
+            
             guard let self = self,
                   let mask = self.gaugeLayer.mask,
                   !self.didAnimation else { return }
@@ -84,6 +87,8 @@ extension GaugeChart {
             self.resumeAnimation(layer: mask, delay: 0)
             
             self.didAnimation = true
+            
+            lock.unlock()
         }
     }
 }


### PR DESCRIPTION
### Description

Read-Write bool is not atomic is Swift. So I used `NSlock` to prevent many threads accessing one boolean variable at same time.