### PR TITLE
Remove lock in `resumeAnimation` method

### DIFF
--- a/Sources/SSChart/Bar/BarChart.swift
+++ b/Sources/SSChart/Bar/BarChart.swift
@@ -118,11 +118,7 @@ public class BarChart: UIView {
 // MARK: - public
 extension BarChart: Chart {
     public func resumeAnimation() {
-        let lock = NSLock()
-        
         DispatchQueue.main.async { [weak self] in
-            lock.lock()
-            
             guard let self = self, !self.didAnimation else { return }
 
             for (index, bar) in self.bars.enumerated() {
@@ -134,8 +130,6 @@ extension BarChart: Chart {
             }
             
             self.didAnimation = true
-            
-            lock.unlock()
         }
     }
 }

--- a/Sources/SSChart/Doughnut/DoughnutChart.swift
+++ b/Sources/SSChart/Doughnut/DoughnutChart.swift
@@ -79,11 +79,7 @@ public class DoughnutChart: UIView {
 // MARK: Chart
 extension DoughnutChart: Chart {
     public func resumeAnimation() {
-        let lock = NSLock()
-
         DispatchQueue.main.async { [weak self] in
-            lock.lock()
-            
             guard let self = self,
                   let mask = self.doughnutLayer.mask,
                   !self.didAnimation else { return }
@@ -93,8 +89,6 @@ extension DoughnutChart: Chart {
             self.resumeAnimation(layer: mask, delay: 0)
             
             self.didAnimation = true
-            
-            lock.unlock()
         }
     }
 }

--- a/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/Sources/SSChart/Gauge/GaugeChart.swift
@@ -82,11 +82,7 @@ public class GaugeChart: UIView {
 // MARK: Chart
 extension GaugeChart: Chart {
     public func resumeAnimation() {
-        let lock = NSLock()
-
         DispatchQueue.main.async { [weak self] in
-            lock.lock()
-            
             guard let self = self,
                   let mask = self.gaugeLayer.mask,
                   !self.didAnimation else { return }
@@ -96,8 +92,6 @@ extension GaugeChart: Chart {
             self.resumeAnimation(layer: mask, delay: 0)
             
             self.didAnimation = true
-            
-            lock.unlock()
         }
     }
 }


### PR DESCRIPTION
#3 

### Description

Remove lock in `resumeAnimation()` method. Since `DispatchQueue.main` is serial queue, it is unnecessary to lock and unlock in dispatch main queue.