### PR TITLE
Updates for v1.0.2

### DIFF
--- a/Sources/SSChart/Bar/BarChart.swift
+++ b/Sources/SSChart/Bar/BarChart.swift
@@ -280,7 +280,7 @@ extension BarChart {
 
 // MARK: - animation
 extension BarChart {
-    private func pauseAnimation() {
+    func pauseAnimation() {
         for bar in bars {
             pauseAnimation(layer: bar.layer)
         }

--- a/Sources/SSChart/Bar/BarChart.swift
+++ b/Sources/SSChart/Bar/BarChart.swift
@@ -18,7 +18,7 @@ import UIKit
  If there is a group that has label, groupLabel will be drawn.
  If there is an item that has label, itemLabel will be drawn. The same applies to descriptionLabel.
  */
-public class BarChart: UIView, Chart {
+public class BarChart: UIView {
     /// cgPoints of each group for drawing
     private struct BarPoint {
         let topLeftPoint: CGPoint
@@ -31,8 +31,18 @@ public class BarChart: UIView, Chart {
             self.subPoints = subPoints
         }
     }
-        
-    // MARK: user setup
+    
+    // MARK: public
+    public var items: [BarChartGroupItem] = [] {
+        // TODO: load default data when empty
+        didSet {
+            setNeedsLayout()
+            layoutIfNeeded()
+        }
+    }
+    
+    // MARK: - private
+    // MARK: user custom
     /// space between groups
     private let groupSpace: CGFloat
     /// space between items
@@ -43,6 +53,8 @@ public class BarChart: UIView, Chart {
     private let animationDelayInterval: Double
     private let showAverageLine: Bool
     private let averageLineColor: UIColor
+    /// Bool indicating pause animation at the beginning.
+    private let isAnimationPaused: Bool
     
     // MARK: calculated
     private var showGroupLabel              = false
@@ -59,18 +71,11 @@ public class BarChart: UIView, Chart {
     private var averageLineLayer = CAShapeLayer()
     private var averageValue: CGFloat               = 0
     private var averageLineAnimationDelay: Double    = 0.0
-    
-    // TODO: add margins
         
-    public var items: [BarChartGroupItem] = [] {
-        // TODO: load default data when empty
-        didSet {
-            reload()
-        }
-    }
-    
     private var groupPoints: [BarPoint] = []
     private var bars: [UIView] = []
+    
+    // TODO: add margins
     
     // MARK: - init
     /// - Parameters:
@@ -83,7 +88,8 @@ public class BarChart: UIView, Chart {
     ///   - animationDelayInterval : interval between animation start time for each bar. Default 0.3
     ///   - showAverageLine : Default false
     ///   - averageLineColor: color of average line. Default systemRed
-    public init(frame: CGRect, groupSpace: CGFloat = 10, itemSpace: CGFloat = 3, groupLabelWidth: CGFloat = 52, itemLabelWidth: CGFloat = 52, descriptionLabelWidth: CGFloat = 52, animationDelayInterval: Double = 0.3, showAverageLine: Bool = false, averageLineColor: UIColor = UIColor.systemRed) {
+    ///   - isAnimationPaused: Pause animation at the beginning. Default false.
+    public init(frame: CGRect, groupSpace: CGFloat = 10, itemSpace: CGFloat = 3, groupLabelWidth: CGFloat = 52, itemLabelWidth: CGFloat = 52, descriptionLabelWidth: CGFloat = 52, animationDelayInterval: Double = 0.3, showAverageLine: Bool = false, averageLineColor: UIColor = UIColor.systemRed, isAnimationPaused: Bool = false) {
         self.groupSpace = groupSpace
         self.itemSpace = itemSpace
         self.groupLabelWidth = groupLabelWidth
@@ -92,6 +98,7 @@ public class BarChart: UIView, Chart {
         self.animationDelayInterval = animationDelayInterval
         self.showAverageLine = showAverageLine
         self.averageLineColor = averageLineColor
+        self.isAnimationPaused = isAnimationPaused
         
         super.init(frame: frame)
     }
@@ -99,20 +106,17 @@ public class BarChart: UIView, Chart {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: - override
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        reload()
+    }
 }
 
 // MARK: - public
-extension BarChart {
-    public func pauseAnimation() {
-        for bar in bars {
-            pauseAnimation(layer: bar.layer)
-        }
-        
-        if showAverageLine {
-            pauseAnimation(layer: averageLineLayer)
-        }
-    }
-    
+extension BarChart: Chart {
     public func resumeAnimation() {
         let lock = NSLock()
         
@@ -142,6 +146,10 @@ extension BarChart {
         reset()
         calculateChartData()
         drawChart()
+        
+        if isAnimationPaused {
+            pauseAnimation()
+        }
     }
     
     private func reset() {
@@ -154,7 +162,10 @@ extension BarChart {
         showDescriptionLabel = false
         didAnimation = false
     }
-    
+}
+ 
+// MARK: - data
+extension BarChart {
     private func calculateChartData() {
         let groupCount = items.count
         var itemCount: Int = 0
@@ -203,7 +214,7 @@ extension BarChart {
     }
 }
 
-// MARK: view
+// MARK: - draw
 extension BarChart {
     private func drawChart() {
         for (groupIndex, group) in items.enumerated() {
@@ -267,6 +278,20 @@ extension BarChart {
     }
 }
 
+// MARK: - animation
+extension BarChart {
+    private func pauseAnimation() {
+        for bar in bars {
+            pauseAnimation(layer: bar.layer)
+        }
+        
+        if showAverageLine {
+            pauseAnimation(layer: averageLineLayer)
+        }
+    }
+}
+
+// MARK: - view
 extension BarChart {
     private func createLabel(frame: CGRect, labelItem: BarChartLabelItem, align: NSTextAlignment) -> UILabel {
         let label = UILabel(frame: frame)

--- a/Sources/SSChart/Bar/BarChart.swift
+++ b/Sources/SSChart/Bar/BarChart.swift
@@ -33,7 +33,21 @@ public class BarChart: UIView {
     }
     
     // MARK: public
-    public var items: [BarChartGroupItem] = [] {
+    public var items: [BarChartGroupItem] = [
+        BarChartGroupItem(
+            items: [
+                BarChartItem(value: 2, color: UIColor.systemGray),
+                BarChartItem(value: 3, color: UIColor.systemGray2),
+                BarChartItem(value: 4, color: UIColor.systemGray3)
+            ]
+        ),
+        BarChartGroupItem(
+            items: [
+                BarChartItem(value: 3, color: UIColor.systemGray4),
+                BarChartItem(value: 4, color: UIColor.systemGray5)
+            ]
+        )
+    ] {
         // TODO: load default data when empty
         didSet {
             setNeedsLayout()

--- a/Sources/SSChart/Bar/BarChart.swift
+++ b/Sources/SSChart/Bar/BarChart.swift
@@ -118,11 +118,7 @@ public class BarChart: UIView {
 // MARK: - public
 extension BarChart: Chart {
     public func resumeAnimation() {
-        let lock = NSLock()
-        
         DispatchQueue.main.async { [weak self] in
-            lock.lock()
-            
             guard let self = self, !self.didAnimation else { return }
 
             for (index, bar) in self.bars.enumerated() {
@@ -134,8 +130,6 @@ extension BarChart: Chart {
             }
             
             self.didAnimation = true
-            
-            lock.unlock()
         }
     }
 }

--- a/Sources/SSChart/Common/Chart.swift
+++ b/Sources/SSChart/Common/Chart.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 protocol Chart {
+    func pauseAnimation()
     func resumeAnimation()
 }
 

--- a/Sources/SSChart/Common/Chart.swift
+++ b/Sources/SSChart/Common/Chart.swift
@@ -9,8 +9,6 @@ import Foundation
 import UIKit
 
 protocol Chart {
-    /// pause animation. This should be called after setting items for chart.
-    func pauseAnimation()
     func resumeAnimation()
 }
 

--- a/Sources/SSChart/Doughnut/DoughnutChart.swift
+++ b/Sources/SSChart/Doughnut/DoughnutChart.swift
@@ -79,11 +79,7 @@ public class DoughnutChart: UIView {
 // MARK: Chart
 extension DoughnutChart: Chart {
     public func resumeAnimation() {
-        let lock = NSLock()
-
         DispatchQueue.main.async { [weak self] in
-            lock.lock()
-            
             guard let self = self,
                   let mask = self.doughnutLayer.mask,
                   !self.didAnimation else { return }
@@ -93,8 +89,6 @@ extension DoughnutChart: Chart {
             self.resumeAnimation(layer: mask, delay: 0)
             
             self.didAnimation = true
-            
-            lock.unlock()
         }
     }
 }

--- a/Sources/SSChart/Doughnut/DoughnutChart.swift
+++ b/Sources/SSChart/Doughnut/DoughnutChart.swift
@@ -12,8 +12,8 @@ public class DoughnutChart: UIView {
     
     // MARK: public
     public var items: [DoughnutChartItem] = [
-        DoughnutChartItem(value: 55, color: .black),
-        DoughnutChartItem(value: 45, color: .systemGray)
+        DoughnutChartItem(value: 55, color: .systemGray),
+        DoughnutChartItem(value: 45, color: .systemGray2)
     ] {
         didSet {
             setNeedsLayout()

--- a/Sources/SSChart/Doughnut/DoughnutChart.swift
+++ b/Sources/SSChart/Doughnut/DoughnutChart.swift
@@ -53,7 +53,7 @@ public class DoughnutChart: UIView {
     ///   - outerCircleRadiusRatio: Ratio of width to outer circle radius. Default 2
     ///   - innerCircleRadiusRatio: Ratio of width to innder circle radius. Default 6
     ///   - animationDuration: Default 1.0
-    ///   - pauseAnimation: Pause animation at the beginning. Default false.
+    ///   - isAnimationPaused: Pause animation at the beginning. Default false.
     public init(frame: CGRect, outerCircleRadiusRatio: CGFloat = 2, innerCircleRadiusRatio: CGFloat = 6, animationDuration: Double = 1.0, isAnimationPaused: Bool = false) {
         self.outerCircleRadiusRatio = outerCircleRadiusRatio
         self.innerCircleRadiusRatio = innerCircleRadiusRatio

--- a/Sources/SSChart/Doughnut/DoughnutChart.swift
+++ b/Sources/SSChart/Doughnut/DoughnutChart.swift
@@ -190,7 +190,7 @@ extension DoughnutChart {
         doughnutLayer.mask?.add(animation, forKey: "circleAnimation")
     }
     
-    private func pauseAnimation() {
+    func pauseAnimation() {
         guard let mask = doughnutLayer.mask else {
             return
         }

--- a/Sources/SSChart/Doughnut/DoughnutChart.swift
+++ b/Sources/SSChart/Doughnut/DoughnutChart.swift
@@ -190,7 +190,7 @@ extension DoughnutChart {
         doughnutLayer.mask?.add(animation, forKey: "circleAnimation")
     }
     
-    public func pauseAnimation() {
+    private func pauseAnimation() {
         guard let mask = doughnutLayer.mask else {
             return
         }

--- a/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/Sources/SSChart/Gauge/GaugeChart.swift
@@ -36,6 +36,8 @@ public class GaugeChart: UIView {
     /// ratio of chart width to inner circle radius
     private let innerCircleRadiusRatio: CGFloat
     private let animationDuration: Double
+    /// Bool indicating pause animation at the beginning.
+    private let isAnimationPaused: Bool
     
     // MARK: calculated
     private var outerCircleRadius: CGFloat = 0
@@ -54,11 +56,13 @@ public class GaugeChart: UIView {
     ///   - outerCircleRadiusRatio: Ratio of chart width to outer circle radius. Default 2
     ///   - innerCircleRadiusRatio: Ratio of chart width to innder circle radius. Default 6
     ///   - animationDuration: Default 1.0
-    public init(frame: CGRect, gaugeWidth: CGFloat = 15, outerCircleRadiusRatio: CGFloat = 2, innerCircleRadiusRatio: CGFloat = 6, animationDuration: Double = 1.0) {
+    ///   - pauseAnimation: Pause animation at the beginning. Default false.
+    public init(frame: CGRect, gaugeWidth: CGFloat = 15, outerCircleRadiusRatio: CGFloat = 2, innerCircleRadiusRatio: CGFloat = 6, animationDuration: Double = 1.0, isAnimationPaused: Bool = false) {
         self.gaugeWidth = gaugeWidth
         self.outerCircleRadiusRatio = outerCircleRadiusRatio
         self.innerCircleRadiusRatio = innerCircleRadiusRatio
         self.animationDuration = animationDuration
+        self.isAnimationPaused = isAnimationPaused
         
         super.init(frame: frame)
     }
@@ -78,14 +82,6 @@ public class GaugeChart: UIView {
 // MARK: - public
 // MARK: Chart
 extension GaugeChart: Chart {
-    public func pauseAnimation() {
-        guard let mask = gaugeLayer.mask else {
-            return
-        }
-        
-        pauseAnimation(layer: mask)
-    }
-    
     public func resumeAnimation() {
         let lock = NSLock()
 
@@ -114,6 +110,10 @@ extension GaugeChart {
         calculateChartData()
         drawChart()
         addAnimation()
+        
+        if isAnimationPaused {
+            pauseAnimation()
+        }
     }
     
     // MARK: - reset
@@ -195,6 +195,13 @@ extension GaugeChart {
         gaugeLayer.mask?.add(animation, forKey: "circleAnimation")
     }
     
+    private func pauseAnimation() {
+        guard let mask = gaugeLayer.mask else {
+            return
+        }
+        
+        pauseAnimation(layer: mask)
+    }
 }
 
 extension GaugeChart {

--- a/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/Sources/SSChart/Gauge/GaugeChart.swift
@@ -14,8 +14,10 @@ public class GaugeChart: UIView {
 
     // MARK: public
     public var items: [GaugeChartItem] = [
-        GaugeChartItem(value: 55, color: .black),
-        GaugeChartItem(value: 45, color: .systemGray)
+        GaugeChartItem(value: 55, color: .systemGray),
+        GaugeChartItem(value: 45, color: .systemGray2),
+        GaugeChartItem(value: 35, color: .systemGray3)
+
     ] {
         didSet {
             setNeedsLayout()

--- a/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/Sources/SSChart/Gauge/GaugeChart.swift
@@ -82,11 +82,7 @@ public class GaugeChart: UIView {
 // MARK: Chart
 extension GaugeChart: Chart {
     public func resumeAnimation() {
-        let lock = NSLock()
-
         DispatchQueue.main.async { [weak self] in
-            lock.lock()
-            
             guard let self = self,
                   let mask = self.gaugeLayer.mask,
                   !self.didAnimation else { return }
@@ -96,8 +92,6 @@ extension GaugeChart: Chart {
             self.resumeAnimation(layer: mask, delay: 0)
             
             self.didAnimation = true
-            
-            lock.unlock()
         }
     }
 }

--- a/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/Sources/SSChart/Gauge/GaugeChart.swift
@@ -55,7 +55,7 @@ public class GaugeChart: UIView {
     ///   - outerCircleRadiusRatio: Ratio of chart width to outer circle radius. Default 2
     ///   - innerCircleRadiusRatio: Ratio of chart width to innder circle radius. Default 6
     ///   - animationDuration: Default 1.0
-    ///   - pauseAnimation: Pause animation at the beginning. Default false.
+    ///   - isAnimationPaused: Pause animation at the beginning. Default false.
     public init(frame: CGRect, gaugeWidth: CGFloat = 15, outerCircleRadiusRatio: CGFloat = 2, innerCircleRadiusRatio: CGFloat = 6, animationDuration: Double = 1.0, isAnimationPaused: Bool = false) {
         self.gaugeWidth = gaugeWidth
         self.outerCircleRadiusRatio = outerCircleRadiusRatio
@@ -130,9 +130,8 @@ extension GaugeChart {
     }
 }
 
-
+// MARK: - data
 extension GaugeChart {
-    // MARK: - data
     private func calculateChartData() {
         calculateSizeProperties()
         calculatePercentages()

--- a/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/Sources/SSChart/Gauge/GaugeChart.swift
@@ -13,7 +13,6 @@ import UIKit
 public class GaugeChart: UIView {
 
     // MARK: public
-    // 유효하지 않은 값 / 새로 데이터 안 들어올 때 기본 회색 차트 노출하게 해야 함
     public var items: [GaugeChartItem] = [
         GaugeChartItem(value: 55, color: .black),
         GaugeChartItem(value: 45, color: .systemGray)

--- a/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/Sources/SSChart/Gauge/GaugeChart.swift
@@ -193,7 +193,7 @@ extension GaugeChart {
         gaugeLayer.mask?.add(animation, forKey: "circleAnimation")
     }
     
-    private func pauseAnimation() {
+    func pauseAnimation() {
         guard let mask = gaugeLayer.mask else {
             return
         }


### PR DESCRIPTION
### Description 

* Support drawing chart using autolayout. 
  *`pauseAnimation()` method is no longer available. Instead, set `isAnimationPaused` option to set whether to pause animation at the beginning in the initializer.
* Remove lock in `resumeAnimation()` method.
* Show default greyish chart if no data is set to chart.
  ![Simulator Screen Recording - iPhone 12 Pro - 2022-08-30 at 10 19 01](https://user-images.githubusercontent.com/41438361/187351773-c5d9b0e0-f1d9-40ef-a8ff-6fc6aa976feb.gif)
